### PR TITLE
Stop writing to sys.stdout

### DIFF
--- a/rpdb/__init__.py
+++ b/rpdb/__init__.py
@@ -15,7 +15,7 @@ class Rpdb(pdb.Pdb):
 
         # Writes to stdout are forbidden in mod_wsgi environments
         try:
-            print("pdb is running on %s:%d" % (addr, port))
+            sys.stderr.write("pdb is running on %s:%d\n" % (addr, port))
         except IOError:
             pass
 


### PR DESCRIPTION
- Printing to stdout was messing up hadoop streaming jobs.
- There also appears to be no reason to re-assign sys.stdout and sys.stdin
