### PR TITLE
'quit' and 'q' debugger command fixes

### DIFF
--- a/rpdb/__init__.py
+++ b/rpdb/__init__.py
@@ -6,6 +6,7 @@ __version__ = "0.1.5"
 import pdb
 import socket
 import sys
+import traceback
 
 
 class Rpdb(pdb.Pdb):
@@ -77,4 +78,4 @@ def set_trace(addr="127.0.0.1", port=4444):
     try:
         debugger.set_trace(sys._getframe().f_back)
     except Exception:
-        print(Exception)
+        traceback.print_exc()


### PR DESCRIPTION
This pull:
- Makes 'quit' command do underlying pdb 'do_quit', rather than 'do_continue'.
- Make s'q' command restore stdout and stdin
- Makes EOF do underlying EOF action, rather than just 'continue'.
- Removes Python 2.5.2 (and presumably, 2.5 and 2.6 in general) incompatibility.
