### PR TITLE
Make repeated rpdb.set_trace() on the same port while within rpdb.set_trace() a no-op

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,16 +1,12 @@
-0.1.6 (2014-10-15)
-==================
-
- - Make q/quit do proper cleanup (@kenmanheimer)
- - Benignly disregard repeated rpdb.set_trace() to same port as currently
-   active session (@kenmanheimer)
- - Extend backwards compatibility down to Python 2.5 (@kenmanheimer)
-
 0.1.5 (YYYY-MM-DD)
 ==================
 
  - Write addr/port to stderr instead of stdout (thanks to @onlynone).
  - Allow for dynamic host port (thanks to @onlynone).
+ - Make q/quit do proper cleanup (@kenmanheimer)
+ - Benignly disregard repeated rpdb.set_trace() to same port as currently
+   active session (@kenmanheimer)
+ - Extend backwards compatibility down to Python 2.5 (@kenmanheimer)
 
 0.1.4 (2014-04-28)
 ==================

--- a/rpdb/__init__.py
+++ b/rpdb/__init__.py
@@ -1,7 +1,7 @@
 """Remote Python Debugger (pdb wrapper)."""
 
 __author__ = "Bertrand Janin <b@janin.com>"
-__version__ = "0.1.6"
+__version__ = "0.1.5"
 
 import pdb
 import socket
@@ -82,7 +82,7 @@ def set_trace(addr="127.0.0.1", port=4444):
     try:
         debugger = Rpdb(addr=addr, port=port)
     except socket.error:
-        if OCCUPIED.isClaimed(port, sys.stdout):
+        if OCCUPIED.is_claimed(port, sys.stdout):
             # rpdb is already on this port - good enough, let it go on:
             sys.stdout.write("(Recurrent rpdb invocation ignored)\n")
             return
@@ -104,18 +104,22 @@ class OccupiedPorts(object):
     Determination is according to whether a file handle is equal to what is
     registered against the specified port.
     """
+
     def __init__(self):
         self.lock = threading.RLock()
         self.claims = {}
+
     def claim(self, port, handle):
         self.lock.acquire(True)
-        self.claims[port] = handle
+        self.claims[port] = id(handle)
         self.lock.release()
-    def isClaimed(self, port, handle):
+
+    def is_claimed(self, port, handle):
         self.lock.acquire(True)
-        got = (self.claims.get(port) == handle)
+        got = (self.claims.get(port) == id(handle))
         self.lock.release()
         return got
+
     def unclaim(self, port):
         self.lock.acquire(True)
         del self.claims[port]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except IOError:
 
 setup(
     name="rpdb",
-    version="0.1.6",
+    version="0.1.5",
     description="pdb wrapper with remote access via tcp socket",
     long_description=README + "\n\n" + CHANGES,
     author="Bertrand Janin",


### PR DESCRIPTION
This reliably ignores recursive rpdb.set_trace() to the same port as a currently operating one.
- It ignores failure to bind to a port if the port is currently occupied by rpdb,
- ... but raises an exception if it's occupied but not by rpdb.
- It uses locking for thread safety

Without this change, hitting and rpdb.set_trace() while already rpdb-debugging to the same port would clobber the run with an exception. Now you can rpdb.set_trace() scattered throughout your code, or hit it multiple times around a loop, without a problem.
