### PR TITLE
adding post_mortem, similar to pdb

### DIFF
--- a/rpdb/__init__.py
+++ b/rpdb/__init__.py
@@ -111,6 +111,15 @@ def set_trace(addr="127.0.0.1", port=4444):
         traceback.print_exc()
 
 
+def post_mortem(addr="127.0.0.1", port=4444):
+    
+    debugger = rpdb.Rpdb(addr=addr, port=port)
+    type, value, tb = sys.exc_info()
+    traceback.print_exc()
+    debugger.reset()
+    debugger.interaction(None, tb)
+
+
 class OccupiedPorts(object):
     """Maintain rpdb port versus stdin/out file handles.
 

--- a/rpdb/__init__.py
+++ b/rpdb/__init__.py
@@ -113,7 +113,7 @@ def set_trace(addr="127.0.0.1", port=4444):
 
 def post_mortem(addr="127.0.0.1", port=4444):
     
-    debugger = rpdb.Rpdb(addr=addr, port=port)
+    debugger = Rpdb(addr=addr, port=port)
     type, value, tb = sys.exc_info()
     traceback.print_exc()
     debugger.reset()


### PR DESCRIPTION
@tamentis, I was having difficulty debugging a Spark job locally, and my friend pointed to your repo. My Spark job was throwing an exception inside some library on the worker node, so `set_trace` wasn't enough. I added this `post_mortem` function, and got great results! The work flow was:

```
import external_lib

def some_function_on_worker_node():
   import rpdb
   try:
     external_lib.failing_func()
  except:
      rpdb.post_mortem()
```

and `nc 127.0.0.1 4444` got me right into the library's broken parts. 

Thanks for this little library!

  