### PR TITLE
Read the README file with UTF-8 encoding.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,17 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import os
 from distutils.core import setup
+from io import open
 
 
 here = os.path.abspath(os.path.dirname(__file__))
 try:
-    README = open(os.path.join(here, 'README.rst')).read()
+    README = open(os.path.join(here, 'README.rst'), encoding='utf8').read()
     CHANGES = open(os.path.join(here, 'CHANGES.txt')).read()
 except IOError:
     README = CHANGES = ''
+
 
 setup(
     name="rpdb",


### PR DESCRIPTION
This commit fixes an install issue in Python 3.5 where the read() function raises an encoding error. It uses
the open function from the io module so that the code will be compatible with both Python 2 and 3.