### PR TITLE
Ensure socket closes properly

### DIFF
--- a/rpdb/__init__.py
+++ b/rpdb/__init__.py
@@ -59,13 +59,16 @@ class Rpdb(pdb.Pdb):
                          stdin=FileObjectWrapper(handle, self.old_stdin),
                          stdout=FileObjectWrapper(handle, self.old_stdin))
         sys.stdout = sys.stdin = handle
+        self.handle = handle
         OCCUPIED.claim(port, sys.stdout)
 
     def shutdown(self):
         """Revert stdin and stdout, close the socket."""
         sys.stdout = self.old_stdout
         sys.stdin = self.old_stdin
+        self.handle.close()
         OCCUPIED.unclaim(self.port)
+        self.skt.shutdown(socket.SHUT_RDWR)
         self.skt.close()
 
     def do_continue(self, arg):


### PR DESCRIPTION
The socket is being held open by the writable handle. Close both the handle and the socket.
To do this we need to store the handle as a member variable.