### PR TITLE
Close #21: Fix encoding and isatty errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
 MANIFEST
+*.py[cod]

--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,12 @@ to continue is to access rpdb using telnet, netcat, etc..::
 
     nc 127.0.0.1 4444
 
+Besides addr and port, the `Rpdb` class can also accept `encoding`::
+
+    import rpdb
+    debugger = rpdb.Rpdb(addr='127.0.0.1', port=12345, encoding='UTF-8')
+    debugger.set_trace()
+
 Installation in CPython (standard Python)
 -----------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,16 @@ Besides addr and port, the `Rpdb` class can also accept `encoding`::
     debugger = rpdb.Rpdb(addr='127.0.0.1', port=12345, encoding='UTF-8')
     debugger.set_trace()
 
+In rpdb continue and quit have different meanings than in the standard
+interpereter:
+
+- continue: Doesn't close the socket, and the application will continue to run
+  stopping on other breakpoints or calls to set_trace.
+
+- quit: Quits the debugging, clearing breakpoints, and closing the socket.
+
+- exit: Abort the running application.
+
 Installation in CPython (standard Python)
 -----------------------------------------
 

--- a/rpdb/__init__.py
+++ b/rpdb/__init__.py
@@ -68,7 +68,7 @@ class Rpdb(pdb.Pdb):
         pdb.Pdb.__init__(self, completekey='tab', stdin=handle, stdout=handle)
         sys.stdout = sys.stdin = handle
         self.handle = handle
-        OCCUPIED.claim(port, sys.stdout)
+        OCCUPIED.claim(port, self)
 
     def shutdown(self):
         """Revert stdin and stdout, close the socket."""
@@ -79,23 +79,22 @@ class Rpdb(pdb.Pdb):
         self.skt.shutdown(socket.SHUT_RDWR)
         self.skt.close()
 
-    def do_continue(self, arg):
-        """Clean-up and do underlying continue."""
+    def do_quit(self, arg):
+        """Quit debugger but let application continue running."""
         try:
+            self.clear_all_breaks()
             return pdb.Pdb.do_continue(self, arg)
         finally:
             self.shutdown()
 
-    do_c = do_cont = do_continue
+    do_q = do_quit
 
-    def do_quit(self, arg):
-        """Clean-up and do underlying quit."""
+    def do_exit(self, arg):
+        """Abort program being executed."""
         try:
             return pdb.Pdb.do_quit(self, arg)
         finally:
             self.shutdown()
-
-    do_q = do_exit = do_quit
 
     def do_EOF(self, arg):
         """Clean-up and do underlying EOF."""
@@ -114,11 +113,12 @@ def set_trace(addr=DEFAULT_ADDR, port=DEFAULT_PORT, frame=None):
     try:
         debugger = Rpdb(addr=addr, port=port)
     except socket.error:
-        if OCCUPIED.is_claimed(port, sys.stdout):
-            # rpdb is already on this port - good enough, let it go on:
-            sys.stdout.write("(Recurrent rpdb invocation ignored)\n")
-            return
-        else:
+        debugger = OCCUPIED.get_my_rpdb(port)
+        if not debugger:
+            if OCCUPIED.is_claimed(port):
+                # rpdb is already on this port - good enough, let it go on:
+                sys.stdout.write("(Recurrent rpdb invocation ignored)\n")
+                return
             # Port occupied by something else.
             raise
     try:
@@ -160,14 +160,24 @@ class OccupiedPorts(object):
 
     def claim(self, port, handle):
         self.lock.acquire(True)
-        self.claims[port] = id(handle)
+        self.claims[port] = (handle, self.thread_id)
         self.lock.release()
 
-    def is_claimed(self, port, handle):
+    def is_claimed(self, port):
         self.lock.acquire(True)
-        got = (self.claims.get(port) == id(handle))
+        got = port in self.claims
         self.lock.release()
         return got
+
+    @property
+    def thread_id(self):
+        return threading.current_thread().ident
+
+    def get_my_rpdb(self, port):
+        rpdb_inst, thread_id = self.claims[port]
+        if thread_id == self.thread_id:
+            return rpdb_inst
+        return None
 
     def unclaim(self, port):
         self.lock.acquire(True)

--- a/rpdb/__init__.py
+++ b/rpdb/__init__.py
@@ -72,6 +72,7 @@ class Rpdb(pdb.Pdb):
 
     def shutdown(self):
         """Revert stdin and stdout, close the socket."""
+        sys.stdout.write('Closing port %s\n' % self.port)
         sys.stdout = self.old_stdout
         sys.stdin = self.old_stdin
         self.handle.close()


### PR DESCRIPTION
On commit 9c9d4f487c81bd5c69a06d636a5121dcf00ba246 we added a wrapper to
provide missing parameters (ie: `encoding`) in the object returned by
`makefile`, unfortunately this didn't resolve all problems, as there are
some cases, like in method oslo_utils.encodeutils.safe_decode where when
accessing sys.stdin.encoding we would still get an error:

  AttributeError: "'_fileobject' object has no attribute 'encoding'"

This patch fixes this issue and allows us to set the encoding when
instantiating the Rpdb object.

The way this has been fixed depends on the Python version:

- For python 2 we extend _fileobject and add `errors` and `encoding`
  variables as well as the `isatty` method.

- For python 3 we pass `encoding` to the `makefile` call and then create
  class attributes `errors` and `isatty` (since we cannot modify the
  instance itself).