### PR TITLE
Fix Rpdb init when debugger_base is wrong.

### DIFF
--- a/rpdb/__init__.py
+++ b/rpdb/__init__.py
@@ -105,7 +105,7 @@ class FileObjectWrapper(object):
 
 
 class Rpdb:
-    def __init__(self, addr=None, port=None, debugger_base=t.Type[pdb.Pdb]):
+    def __init__(self, addr=None, port=None, debugger_base: t.Type[pdb.Pdb] = pdb.Pdb):
         """Initialize the socket and initialize pdb."""
 
         self.debugger = debugger_base


### PR DESCRIPTION
Broken by https://github.com/tamentis/rpdb/commit/a5d81372cf4bbe7d13fdeea56de1eebd3299647b